### PR TITLE
Allow workout generation from a split or body part

### DIFF
--- a/components/submit-button.tsx
+++ b/components/submit-button.tsx
@@ -47,7 +47,7 @@ export function SubmitButton({ mode, loading, canSubmit }: SubmitButtonProps) {
           className="text-[12px] text-center mt-[10px]"
           style={{ color: "#555" }}
         >
-          Select a workout split to continue
+          Select a workout split or body part to continue
         </p>
       )}
 

--- a/lib/hooks/use-workout-form.ts
+++ b/lib/hooks/use-workout-form.ts
@@ -63,7 +63,7 @@ export function useWorkoutForm() {
 
   const canSubmit = (mode: GenerationMode): boolean => {
     if (mode === "program") return !!programSplit;
-    return !!workoutType; // workout requires split
+    return !!workoutType || selectedBodyParts.length > 0;
   };
 
   const getGenerationParams = (mode: GenerationMode): GenerationParams => ({


### PR DESCRIPTION
## Summary
- Updated workout-mode submit eligibility so Generate works when the user selects either a workout split or at least one target body part.
- Kept program-mode gating unchanged.
- Aligned the workout helper text with the new rule.

## Testing
- `pnpm lint` passed.
- `pnpm build` passed.
- Verified in the local app that workout submit is disabled with no split/body part, enabled with a split or body part, and remains disabled when only duration, equipment, experience level, or notes are filled. Program mode still requires a program split.