### PR TITLE
Refine program progression notes and rest-time formatting

### DIFF
--- a/components/exercise-card.tsx
+++ b/components/exercise-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { ExerciseDetails } from "@/components/exercise-details";
 import type { Exercise } from "@/lib/workout-types";
 
 const ChevronIcon = ({ open }: { open: boolean }) => (
@@ -92,80 +93,7 @@ export function ExerciseCard({ exercise, index }: ExerciseCardProps) {
           className="border-t px-5 py-4 animate-fade-up-sm"
           style={{ borderColor: "#232323" }}
         >
-          {/* Stat pills */}
-          <div className="flex gap-2 flex-wrap mb-[14px]">
-            {[
-              { value: String(exercise.sets), label: "Sets" },
-              { value: exercise.reps,         label: "Reps" },
-              { value: exercise.restTime,     label: "Rest" },
-            ].map(({ value, label }) => (
-              <div
-                key={label}
-                className="inline-flex flex-col items-center px-[18px] py-[9px] min-w-[72px] rounded-[var(--wg-radius-sm)]"
-                style={{ background: "#181818" }}
-              >
-                <span
-                  className="text-[18px] font-bold"
-                  style={{ color: "#edeae6" }}
-                >
-                  {value}
-                </span>
-                <span
-                  className="text-[10px] uppercase tracking-[0.06em] mt-[2px]"
-                  style={{ color: "#555" }}
-                >
-                  {label}
-                </span>
-              </div>
-            ))}
-          </div>
-
-          {/* Muscle tags */}
-          {exercise.muscleGroups.length > 0 && (
-            <div className="flex flex-wrap gap-[6px] mb-[14px]">
-              {exercise.muscleGroups.map((muscle, i) => (
-                <span
-                  key={i}
-                  className="px-[9px] py-[3px] rounded-[4px] text-[11px] font-semibold tracking-[0.03em]"
-                  style={{
-                    background: "var(--wg-accent-sub)",
-                    color: "var(--wg-accent)",
-                  }}
-                >
-                  {muscle}
-                </span>
-              ))}
-            </div>
-          )}
-
-          {/* Form tips */}
-          {exercise.formTips && exercise.formTips.length > 0 && (
-            <div>
-              <div
-                className="text-[10px] font-bold uppercase tracking-[0.08em] mb-[9px]"
-                style={{ color: "#555" }}
-              >
-                Form Tips
-              </div>
-              <ul className="flex flex-col gap-[7px]">
-                {exercise.formTips.map((tip, i) => (
-                  <li
-                    key={i}
-                    className="flex gap-[10px] text-[13px] leading-[1.5]"
-                    style={{ color: "#555" }}
-                  >
-                    <span
-                      className="flex-shrink-0"
-                      style={{ color: "var(--wg-accent)" }}
-                    >
-                      —
-                    </span>
-                    <span>{tip}</span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
+          <ExerciseDetails exercise={exercise} />
         </div>
       )}
     </div>

--- a/components/exercise-details.tsx
+++ b/components/exercise-details.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import type { Exercise } from "@/lib/workout-types";
+
+interface ExerciseDetailsProps {
+  exercise: Pick<
+    Exercise,
+    "sets" | "reps" | "restTime" | "muscleGroups" | "formTips"
+  >;
+  compact?: boolean;
+}
+
+export function ExerciseDetails({
+  exercise,
+  compact = false,
+}: ExerciseDetailsProps) {
+  const statPillClassName = compact
+    ? "inline-flex flex-col items-center px-[14px] py-[8px] min-w-[64px] rounded-[var(--wg-radius-sm)]"
+    : "inline-flex flex-col items-center px-[18px] py-[9px] min-w-[72px] rounded-[var(--wg-radius-sm)]";
+
+  const statValueClassName = compact
+    ? "text-[16px] font-bold"
+    : "text-[18px] font-bold";
+
+  const tipClassName = compact
+    ? "flex gap-[8px] text-[12px] leading-[1.5]"
+    : "flex gap-[10px] text-[13px] leading-[1.5]";
+
+  return (
+    <>
+      {/* Stat pills */}
+      <div className="mb-[14px] flex flex-wrap gap-2">
+        {[
+          { value: String(exercise.sets), label: "Sets" },
+          { value: exercise.reps, label: "Reps" },
+          { value: exercise.restTime, label: "Rest" },
+        ].map(({ value, label }) => (
+          <div
+            key={label}
+            className={statPillClassName}
+            style={{ background: "#181818" }}
+          >
+            <span className={`${statValueClassName} text-[#edeae6]`}>
+              {value}
+            </span>
+            <span className="mt-[2px] text-[10px] uppercase tracking-[0.06em] text-[#8a857d]">
+              {label}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {/* Muscle tags */}
+      {exercise.muscleGroups.length > 0 && (
+        <div className="flex flex-wrap gap-[6px] mb-[14px]">
+          {exercise.muscleGroups.map((muscle, i) => (
+            <span
+              key={i}
+              className="px-[9px] py-[3px] rounded-[4px] text-[11px] font-semibold tracking-[0.03em]"
+              style={{
+                background: "var(--wg-accent-sub)",
+                color: "var(--wg-accent)",
+              }}
+            >
+              {muscle}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Form tips */}
+      {exercise.formTips.length > 0 && (
+        <div>
+          <div className="mb-[9px] text-[10px] font-bold uppercase tracking-[0.08em] text-[#8a857d]">
+            Form Tips
+          </div>
+          <ul className="flex flex-col gap-[7px]">
+            {exercise.formTips.map((tip, i) => (
+              <li key={i} className={`${tipClassName} text-[#8a857d]`}>
+                <span
+                  className="flex-shrink-0"
+                  style={{ color: "var(--wg-accent)" }}
+                >
+                  -
+                </span>
+                <span>{tip}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </>
+  );
+}

--- a/components/program-results.tsx
+++ b/components/program-results.tsx
@@ -235,9 +235,12 @@ export const ProgramResults = forwardRef<HTMLDivElement, ProgramResultsProps>(
           ))}
         </div>
 
-        {program.weeklyNotes && (
+        {program.progressionNotes && (
           <div className="mt-4 rounded-[var(--wg-radius)] border border-[#232323] bg-[#111111] px-[14px] py-3 text-[13px] leading-[1.6] text-[#8a857d]">
-            {program.weeklyNotes}
+            <div className="mb-[7px] text-[10px] font-bold uppercase tracking-[0.08em] text-[#8a857d]">
+              Progression Plan
+            </div>
+            <div>{program.progressionNotes}</div>
           </div>
         )}
       </div>

--- a/components/program-results.tsx
+++ b/components/program-results.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { forwardRef, useState } from "react";
+import { ExerciseDetails } from "@/components/exercise-details";
 import type { ProgramData, ProgramDay } from "@/lib/workout-types";
 
 const CopyIcon = () => (
@@ -68,8 +69,10 @@ function ProgramDayCard({
         animationDelay: `${index * 60}ms`,
       }}
     >
-      <div
-        className="flex items-center gap-[14px] px-5 py-4 cursor-pointer select-none"
+      <button
+        type="button"
+        aria-expanded={isOpen}
+        className="flex w-full items-center gap-[14px] bg-transparent px-5 py-4 text-left cursor-pointer select-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[var(--wg-accent)]"
         onClick={onToggle}
       >
         <div
@@ -79,62 +82,74 @@ function ProgramDayCard({
           D{index + 1}
         </div>
         <div className="flex-1 min-w-0">
-          <div
-            className="font-semibold text-[14px]"
-            style={{ color: "#edeae6" }}
-          >
+          <div className="font-semibold text-[14px] text-[#edeae6]">
             {day.day} — {day.title}
           </div>
-          {day.focus && (
-            <div className="text-[12px] mt-[2px]" style={{ color: "#555" }}>
-              {day.focus}
-            </div>
-          )}
+          <div className="mt-[2px] flex flex-col gap-x-2 gap-y-[2px] text-[12px] text-[#8a857d] sm:flex-row sm:flex-wrap sm:items-center">
+            {day.focus && <span>{day.focus}</span>}
+            {day.focus && (
+              <span className="hidden sm:inline" aria-hidden="true">
+                |
+              </span>
+            )}
+            <span>Est. {day.estimatedDuration}</span>
+          </div>
         </div>
         <div style={{ color: "#2e2e2e", flexShrink: 0 }}>
           <ChevronIcon open={isOpen} />
         </div>
-      </div>
+      </button>
 
       {isOpen && (
         <div
           className="border-t px-5 py-[14px] animate-fade-up-sm"
           style={{ borderColor: "#232323" }}
         >
-          {day.exercises.map((ex, j) => (
-            <div
-              key={j}
-              className="flex items-center gap-3 py-[9px]"
-              style={{
-                borderBottom:
-                  j < day.exercises.length - 1 ? "1px solid #232323" : "none",
-              }}
-            >
-              <span
-                className="text-[11px] w-4 flex-shrink-0"
-                style={{ color: "#2e2e2e" }}
+          {day.exercises.map((ex, j) => {
+            const musclePreview = ex.muscleGroups.slice(0, 3).join(", ");
+
+            return (
+              <div
+                key={j}
+                className="py-4"
+                style={{
+                  borderBottom:
+                    j < day.exercises.length - 1
+                      ? "1px solid #232323"
+                      : "none",
+                }}
               >
-                {j + 1}
-              </span>
-              <span
-                className="flex-1 text-[14px] font-medium"
-                style={{ color: "#edeae6" }}
-              >
-                {ex.name}
-              </span>
-              <span
-                className="text-[12px] font-medium flex-shrink-0"
-                style={{ color: "#555" }}
-              >
-                {ex.sets}×{ex.reps}
-              </span>
-            </div>
-          ))}
+                <div className="flex items-start gap-3">
+                  <span className="w-4 flex-shrink-0 pt-[3px] text-[11px] text-[#8a857d]">
+                    {j + 1}
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+                      <div className="min-w-0">
+                        <div className="text-[14px] font-medium leading-[1.35] text-[#edeae6]">
+                          {ex.name}
+                        </div>
+                        {musclePreview && (
+                          <div className="mt-[3px] text-[12px] leading-[1.45] text-[#8a857d]">
+                            {musclePreview}
+                          </div>
+                        )}
+                      </div>
+                      <div className="flex flex-wrap gap-x-3 gap-y-1 text-[12px] font-medium text-[#8a857d] sm:flex-shrink-0 sm:justify-end sm:text-right">
+                        <span>{ex.sets} x {ex.reps}</span>
+                        <span>rest {ex.restTime}</span>
+                      </div>
+                    </div>
+                    <div className="mt-3">
+                      <ExerciseDetails exercise={ex} compact />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
           {day.notes && (
-            <div
-              className="mt-3 px-3 py-2 rounded-[var(--wg-radius-sm)] text-[12px] leading-[1.5]"
-              style={{ background: "#181818", color: "#555" }}
-            >
+            <div className="mt-3 rounded-[var(--wg-radius-sm)] bg-[#181818] px-3 py-2 text-[12px] leading-[1.5] text-[#8a857d]">
               {day.notes}
             </div>
           )}
@@ -170,16 +185,10 @@ export const ProgramResults = forwardRef<HTMLDivElement, ProgramResultsProps>(
               >
                 Generated Program
               </div>
-              <div
-                className="text-[22px] font-bold tracking-[-0.02em]"
-                style={{ color: "#edeae6" }}
-              >
+              <div className="text-[22px] font-bold tracking-[-0.02em] text-[#edeae6]">
                 Your Program
               </div>
-              <div
-                className="text-[13px] mt-1 leading-[1.6] max-w-[420px]"
-                style={{ color: "#555" }}
-              >
+              <div className="mt-1 max-w-[420px] text-[13px] leading-[1.6] text-[#8a857d]">
                 {program.weeklyOverview ||
                   `${program.days.length}-day training program`}
               </div>
@@ -188,12 +197,11 @@ export const ProgramResults = forwardRef<HTMLDivElement, ProgramResultsProps>(
               <button
                 type="button"
                 onClick={onCopyFull}
-                className="inline-flex items-center gap-[6px] px-[14px] py-2 text-[13px] font-medium rounded-[var(--wg-radius-sm)] border transition-all duration-150 cursor-pointer leading-none"
-                style={{
-                  background: "transparent",
-                  borderColor: copiedFull ? "var(--wg-accent)" : "#232323",
-                  color: copiedFull ? "var(--wg-accent)" : "#555",
-                }}
+                className={`inline-flex cursor-pointer items-center gap-[6px] rounded-[var(--wg-radius-sm)] border px-[14px] py-2 text-[13px] font-medium leading-none transition-all duration-150 ${
+                  copiedFull
+                    ? "border-[var(--wg-accent)] text-[var(--wg-accent)]"
+                    : "border-[#232323] text-[#8a857d]"
+                }`}
               >
                 {copiedFull ? <CheckIcon /> : <CopyIcon />}
                 {copiedFull ? "Copied" : "Copy"}
@@ -202,8 +210,7 @@ export const ProgramResults = forwardRef<HTMLDivElement, ProgramResultsProps>(
               <button
                 type="button"
                 onClick={onReset}
-                className="inline-flex items-center px-[14px] py-2 text-[13px] font-medium rounded-[var(--wg-radius-sm)] border border-[#232323] transition-all duration-150 cursor-pointer leading-none hover:border-[#2e2e2e] hover:text-[#edeae6]"
-                style={{ background: "transparent", color: "#555" }}
+                className="inline-flex cursor-pointer items-center rounded-[var(--wg-radius-sm)] border border-[#232323] bg-transparent px-[14px] py-2 text-[13px] font-medium leading-none text-[#8a857d] transition-all duration-150 hover:border-[#2e2e2e] hover:text-[#edeae6]"
               >
                 New Program
               </button>
@@ -211,10 +218,7 @@ export const ProgramResults = forwardRef<HTMLDivElement, ProgramResultsProps>(
           </div>
         </div>
 
-        <div
-          className="text-[10px] font-bold uppercase tracking-[0.08em] mb-[10px]"
-          style={{ color: "#555" }}
-        >
+        <div className="mb-[10px] text-[10px] font-bold uppercase tracking-[0.08em] text-[#8a857d]">
           Week 1 — Sample Schedule
         </div>
 
@@ -232,14 +236,7 @@ export const ProgramResults = forwardRef<HTMLDivElement, ProgramResultsProps>(
         </div>
 
         {program.weeklyNotes && (
-          <div
-            className="mt-4 px-[14px] py-3 rounded-[var(--wg-radius)] text-[13px] leading-[1.6]"
-            style={{
-              background: "#111111",
-              border: "1px solid #232323",
-              color: "#555",
-            }}
-          >
+          <div className="mt-4 rounded-[var(--wg-radius)] border border-[#232323] bg-[#111111] px-[14px] py-3 text-[13px] leading-[1.6] text-[#8a857d]">
             {program.weeklyNotes}
           </div>
         )}

--- a/lib/program-prompt.ts
+++ b/lib/program-prompt.ts
@@ -87,7 +87,7 @@ IMPORTANT: You MUST respond with ONLY valid JSON in the exact format specified b
 Required JSON structure:
 {
   "weeklyOverview": "Optional one-paragraph overview of the week's structure",
-  "weeklyNotes": "Optional weekly guidance, recovery advice, or progression notes",
+  "progressionNotes": "Optional progression plan explaining how to advance exercises week to week, including when to add load, reps, sets, or difficulty, and when to hold steady",
   "days": [
     {
       "day": "Monday",
@@ -123,7 +123,8 @@ Requirements:
 - Order the "days" entries chronologically within the week
 - Do not include rest days or recovery-only days
 - Every workout day must include "title", "estimatedDuration", and at least 4 "exercises"
-- "focus", "notes", "weeklyOverview", and "weeklyNotes" are optional
+- "focus", "notes", "weeklyOverview", and "progressionNotes" are optional
+- If "progressionNotes" is included, make it progression-specific. Do not repeat the weekly overview; explain how the user should progress the exercises over time.
 
 Remember: Return ONLY the JSON object, no markdown formatting, no code blocks, no additional text.`);
 

--- a/lib/program-prompt.ts
+++ b/lib/program-prompt.ts
@@ -99,7 +99,7 @@ Required JSON structure:
           "name": "Exercise name",
           "sets": 3,
           "reps": "8-10",
-          "restTime": "60s",
+          "restTime": "1 min",
           "muscleGroups": ["Chest", "Triceps"],
           "formTips": [
             "Keep your core engaged throughout the movement",
@@ -123,6 +123,7 @@ Requirements:
 - Order the "days" entries chronologically within the week
 - Do not include rest days or recovery-only days
 - Every workout day must include "title", "estimatedDuration", and at least 4 "exercises"
+- Every exercise "restTime" must be a string in minutes only, e.g., "1 min", "1.5 min", "2 min", "3 min". Use half-minute increments when useful. Do not return rest times in seconds.
 - "focus", "notes", "weeklyOverview", and "progressionNotes" are optional
 - If "progressionNotes" is included, make it progression-specific. Do not repeat the weekly overview; explain how the user should progress the exercises over time.
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -157,7 +157,9 @@ export function formatProgramAsText(program: ProgramData): string {
     text += `${"-".repeat(50)}\n`;
   });
 
-  if (program.weeklyNotes) text += `Weekly Notes:\n${program.weeklyNotes}\n`;
+  if (program.progressionNotes) {
+    text += `Progression Plan:\n${program.progressionNotes}\n`;
+  }
   return text.trimEnd();
 }
 
@@ -184,6 +186,8 @@ export function formatProgramAsTemplate(program: ProgramData): string {
     text += `${"-".repeat(50)}\n`;
   });
 
-  if (program.weeklyNotes) text += `Weekly Notes:\n${program.weeklyNotes}\n`;
+  if (program.progressionNotes) {
+    text += `Progression Plan:\n${program.progressionNotes}\n`;
+  }
   return text.trimEnd();
 }

--- a/lib/workout-prompt.ts
+++ b/lib/workout-prompt.ts
@@ -69,7 +69,7 @@ Required JSON structure:
       "name": "Exercise name",
       "sets": 3,
       "reps": "8-10",
-      "restTime": "60s",
+      "restTime": "1 min",
       "muscleGroups": ["Chest", "Triceps"],
       "formTips": [
         "Keep your core engaged throughout the movement",
@@ -86,7 +86,7 @@ Requirements:
 - "name": Full name of the exercise (required)
 - "sets": Number of sets as an integer (required)
 - "reps": Rep range as a string, can be "8-10", "12-15", "AMRAP", "30 seconds", etc. (required)
-- "restTime": Rest period as a string, e.g., "60s", "90s", "2 minutes" (required)
+- "restTime": Rest period as a string in minutes only, e.g., "1 min", "1.5 min", "2 min", "3 min" (required). Use half-minute increments when useful. Do not return rest times in seconds.
 - "muscleGroups": Array of primary muscle groups targeted (required, at least 1)
 - "formTips": Array of 2-3 specific form cues or tips (required)
 - "estimatedDuration": Total estimated workout duration including warm-up (required)

--- a/lib/workout-types.ts
+++ b/lib/workout-types.ts
@@ -15,7 +15,7 @@ export const ExerciseSchema = z.object({
   name: z.string().min(1),
   sets: z.number().int().positive(),
   reps: z.string().min(1), // "8-10", "AMRAP", etc.
-  restTime: z.string().min(1), // "60s", "90s", etc.
+  restTime: z.string().min(1), // "1 min", "1.5 min", etc.
   muscleGroups: z.array(z.string()).min(1),
   formTips: z.array(z.string()), // No minimum required
 });

--- a/lib/workout-types.ts
+++ b/lib/workout-types.ts
@@ -40,7 +40,7 @@ export const ProgramDaySchema = WorkoutProgramDaySchema;
 const BaseProgramDataSchema = z
   .object({
     weeklyOverview: z.string().optional(),
-    weeklyNotes: z.string().optional(),
+    progressionNotes: z.string().optional(),
     days: z.array(ProgramDaySchema).min(2).max(6),
   })
   .superRefine((value, ctx) => {


### PR DESCRIPTION
## Summary
- Renamed the program-level guidance field from `weeklyNotes` to `progressionNotes` for clearer developer intent.
- Updated the program prompt so the model now returns progression-specific guidance instead of repeating the weekly overview.
- Labeled the UI section as `Progression Plan` and updated copied/exported text to match.
- Added a minutes-only rest-time constraint across workout and program prompts so rest periods come back in `1 min` / `1.5 min` format instead of seconds.

## Testing
- `pnpm lint`
- `pnpm build`