### PR TITLE
Refactor Tailwind styling and remove inline style usage

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -65,14 +65,14 @@
   --destructive: oklch(0.577 0.245 27.325);
 
   /* Dynamic tweakable vars (overridden via JS at runtime) */
-  --wg-accent:       oklch(0.44 0.17 13);
-  --wg-accent-h:     oklch(0.50 0.20 13);
-  --wg-accent-sub:   oklch(0.44 0.17 13 / 0.12);
-  --wg-accent-sub-h: oklch(0.44 0.17 13 / 0.20);
-  --wg-font:         'Space Grotesk', sans-serif;
-  --wg-radius:       8px;
-  --wg-radius-sm:    6px;
-  --wg-radius-lg:    14px;
+  --wg-accent: oklch(0.44 0.17 13);
+  --wg-accent-h: oklch(0.5 0.2 13);
+  --wg-accent-sub: oklch(0.44 0.17 13 / 0.12);
+  --wg-accent-sub-h: oklch(0.44 0.17 13 / 0.2);
+  --wg-font: "Space Grotesk", sans-serif;
+  --wg-radius: 8px;
+  --wg-radius-sm: 6px;
+  --wg-radius-lg: 14px;
 }
 
 /* Keep .dark identical — we force this class on <html> */
@@ -98,7 +98,9 @@
 }
 
 @layer base {
-  *, *::before, *::after {
+  *,
+  *::before,
+  *::after {
     @apply border-border;
     box-sizing: border-box;
   }
@@ -108,28 +110,125 @@
     -webkit-font-smoothing: antialiased;
     min-height: 100vh;
   }
-  ::-webkit-scrollbar { width: 5px; }
-  ::-webkit-scrollbar-track { background: transparent; }
-  ::-webkit-scrollbar-thumb { background: #2e2e2e; border-radius: 3px; }
+  ::-webkit-scrollbar {
+    width: 5px;
+  }
+  ::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  ::-webkit-scrollbar-thumb {
+    background: #2e2e2e;
+    border-radius: 3px;
+  }
 
-  textarea::placeholder { color: #555; }
-  textarea:focus { outline: none; }
+  textarea::placeholder {
+    color: #555;
+  }
+  textarea:focus {
+    outline: none;
+  }
 }
 
 /* ─── Keyframe animations ─────────────────────────────────────── */
 @keyframes fadeUp {
-  from { opacity: 0; transform: translateY(12px); }
-  to   { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 @keyframes pulseBarbell {
-  0%, 100% { opacity: 1; transform: scale(1); }
-  50%       { opacity: 0.5; transform: scale(0.92); }
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.5;
+    transform: scale(0.92);
+  }
 }
 @keyframes spinLoader {
-  from { transform: rotate(0deg); }
-  to   { transform: rotate(360deg); }
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
-.animate-fade-up     { animation: fadeUp 0.35s ease both; }
-.animate-fade-up-sm  { animation: fadeUp 0.2s ease both; }
-.animate-pulse-barbell { animation: pulseBarbell 1.4s ease-in-out infinite; }
+.animate-fade-up {
+  animation: fadeUp 0.35s ease both;
+}
+.animate-fade-up-sm {
+  animation: fadeUp 0.2s ease both;
+}
+.animate-pulse-barbell {
+  animation: pulseBarbell 1.4s ease-in-out infinite;
+}
+.animate-spin-loader {
+  animation: spinLoader 0.7s linear infinite;
+}
+
+@layer utilities {
+  .bg-wg-accent {
+    background-color: var(--wg-accent);
+  }
+  .bg-wg-accent-hover {
+    background-color: var(--wg-accent-h);
+  }
+  .hover\:bg-wg-accent-hover:hover {
+    background-color: var(--wg-accent-h);
+  }
+  .bg-wg-accent-sub {
+    background-color: var(--wg-accent-sub);
+  }
+  .text-wg-accent {
+    color: var(--wg-accent);
+  }
+  .border-wg-accent {
+    border-color: var(--wg-accent);
+  }
+  .focus\:border-wg-accent:focus {
+    border-color: var(--wg-accent);
+  }
+  .outline-wg-accent {
+    outline-color: var(--wg-accent);
+  }
+  .focus-visible\:outline-wg-accent:focus-visible {
+    outline-color: var(--wg-accent);
+  }
+  .bg-error-sub {
+    background-color: oklch(0.44 0.17 13 / 0.08);
+  }
+  .border-error-sub {
+    border-color: oklch(0.44 0.17 13 / 0.25);
+  }
+  .rounded-wg {
+    border-radius: var(--wg-radius);
+  }
+  .rounded-wg-sm {
+    border-radius: var(--wg-radius-sm);
+  }
+  .rounded-wg-lg {
+    border-radius: var(--wg-radius-lg);
+  }
+  .font-wg {
+    font-family: var(--wg-font);
+  }
+  .font-space-grotesk {
+    font-family: var(--font-space-grotesk), sans-serif;
+  }
+  .font-dm-sans {
+    font-family: var(--font-dm-sans), sans-serif;
+  }
+  .font-helvetica-neue {
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  }
+  .shadow-tweaks {
+    box-shadow: 0 24px 48px rgb(0 0 0 / 0.5);
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -114,20 +114,14 @@ const BarbellIcon = ({ size = 44 }: { size?: number }) => (
 function LoadingState({ mode }: { mode: GenerationMode }) {
   return (
     <div className="animate-fade-up flex flex-col items-center gap-[18px] px-5 py-[72px]">
-      <div
-        className="animate-pulse-barbell"
-        style={{ color: "var(--wg-accent)" }}
-      >
+      <div className="animate-pulse-barbell text-wg-accent">
         <BarbellIcon size={44} />
       </div>
       <div className="text-center">
-        <div
-          className="mb-[6px] text-[16px] font-semibold"
-          style={{ color: "#edeae6" }}
-        >
+        <div className="text-foreground mb-[6px] text-[16px] font-semibold">
           Building your {mode}…
         </div>
-        <div className="text-[13px]" style={{ color: "#555" }}>
+        <div className="text-muted-foreground text-[13px]">
           Analyzing your inputs
         </div>
       </div>
@@ -243,14 +237,8 @@ export default function Home() {
   };
 
   return (
-    <main style={{ background: "#090909", minHeight: "100vh" }}>
-      <div
-        style={{
-          maxWidth: 680,
-          margin: "0 auto",
-          padding: "36px 20px 100px",
-        }}
-      >
+    <main className="bg-background min-h-screen">
+      <div className="mx-auto max-w-[680px] px-5 pt-9 pb-[100px]">
         {/* Header + mode toggle */}
         <WorkoutHeader
           mode={mode}
@@ -363,14 +351,7 @@ export default function Home() {
 
             {/* Error message */}
             {error && (
-              <div
-                className="mt-1 mb-2 rounded-[var(--wg-radius)] px-4 py-3 text-[13px]"
-                style={{
-                  background: "oklch(0.44 0.17 13 / 0.08)",
-                  border: "1px solid oklch(0.44 0.17 13 / 0.25)",
-                  color: "var(--wg-accent)",
-                }}
-              >
+              <div className="rounded-wg border-error-sub bg-error-sub text-wg-accent mt-1 mb-2 border px-4 py-3 text-[13px]">
                 {error}
               </div>
             )}

--- a/components/additional-details-input.tsx
+++ b/components/additional-details-input.tsx
@@ -39,23 +39,9 @@ export function AdditionalDetailsInput({
         }
         rows={4}
         maxLength={MAX_CHARACTERS}
-        className="w-full rounded-[var(--wg-radius)] text-[13px] px-[14px] py-3 resize-y leading-[1.55]"
-        style={{
-          background: "#111111",
-          border: "1px solid #232323",
-          color: "#edeae6",
-          outline: "none",
-          fontFamily: "var(--wg-font)",
-          transition: "border-color 0.14s",
-          minHeight: 96,
-        }}
-        onFocus={(e) => (e.currentTarget.style.borderColor = "var(--wg-accent)")}
-        onBlur={(e) => (e.currentTarget.style.borderColor = "#232323")}
+        className="font-wg rounded-wg border-border bg-card text-foreground focus:border-wg-accent min-h-24 w-full resize-y border px-[14px] py-3 text-[13px] leading-[1.55] transition-colors duration-150 outline-none"
       />
-      <div
-        className="text-right text-[11px] mt-[5px]"
-        style={{ color: "#2e2e2e" }}
-      >
+      <div className="text-ring mt-[5px] text-right text-[11px]">
         {value.length}/{MAX_CHARACTERS}
       </div>
     </FormSection>

--- a/components/chip.tsx
+++ b/components/chip.tsx
@@ -20,10 +20,10 @@ export function Chip({
       type="button"
       onClick={onClick}
       className={cn(
-        "rounded-wg-sm inline-flex cursor-pointer items-center justify-center border leading-none whitespace-nowrap transition-all duration-150",
+        "rounded-wg-sm inline-flex cursor-pointer items-center justify-center border leading-none font-semibold whitespace-nowrap transition-all duration-150",
         small ? "px-3 py-[5px] text-xs" : "px-[15px] py-2 text-[13px]",
         active
-          ? "border-wg-accent bg-wg-accent-sub text-wg-accent font-semibold"
+          ? "border-wg-accent bg-wg-accent-sub text-wg-accent"
           : "border-border text-muted-foreground hover:border-ring hover:text-foreground bg-transparent",
         className,
       )}

--- a/components/chip.tsx
+++ b/components/chip.tsx
@@ -20,11 +20,11 @@ export function Chip({
       type="button"
       onClick={onClick}
       className={cn(
-        "inline-flex items-center justify-center whitespace-nowrap rounded-[var(--wg-radius-sm)] border transition-all duration-150 cursor-pointer leading-none tracking-[0.01em]",
+        "rounded-wg-sm inline-flex cursor-pointer items-center justify-center border leading-none whitespace-nowrap transition-all duration-150",
         small ? "px-3 py-[5px] text-xs" : "px-[15px] py-2 text-[13px]",
         active
-          ? "border-[var(--wg-accent)] bg-[var(--wg-accent-sub)] text-[var(--wg-accent)] font-semibold"
-          : "border-[#232323] bg-transparent text-[#555] hover:border-[#2e2e2e] hover:text-[#edeae6]",
+          ? "border-wg-accent bg-wg-accent-sub text-wg-accent font-semibold"
+          : "border-border text-muted-foreground hover:border-ring hover:text-foreground bg-transparent",
         className,
       )}
     >
@@ -41,11 +41,13 @@ interface SectionLabelProps {
 export function SectionLabel({ text, sub }: SectionLabelProps) {
   return (
     <div className="mb-3">
-      <div className="text-[11px] font-bold tracking-[0.08em] uppercase text-[#555]">
+      <div className="text-muted-foreground text-[11px] font-bold tracking-[0.08em] uppercase">
         {text}
       </div>
       {sub && (
-        <div className="text-[12px] text-[#555] mt-1 opacity-80">{sub}</div>
+        <div className="text-muted-foreground mt-1 text-[12px] opacity-80">
+          {sub}
+        </div>
       )}
     </div>
   );
@@ -65,7 +67,7 @@ export function FormSection({
   first = false,
 }: FormSectionProps) {
   return (
-    <div className={cn("pb-6", !first && "border-t border-[#232323] pt-6")}>
+    <div className={cn("pb-6", !first && "border-border border-t pt-6")}>
       <SectionLabel text={label} sub={sub} />
       {children}
     </div>

--- a/components/duration-selector.tsx
+++ b/components/duration-selector.tsx
@@ -2,11 +2,11 @@ import { Chip, FormSection } from "@/components/chip";
 import { workoutDurations, type WorkoutDuration } from "@/lib/workout-options";
 
 const DURATION_LABELS: Record<WorkoutDuration, string> = {
-  "15 minutes":   "15 min",
-  "30 minutes":   "30 min",
-  "45 minutes":   "45 min",
-  "60 minutes":   "60 min",
-  "75+ minutes":  "75+ min",
+  "15 minutes": "15 min",
+  "30 minutes": "30 min",
+  "45 minutes": "45 min",
+  "60 minutes": "60 min",
+  "75+ minutes": "75+ min",
 };
 
 interface DurationSelectorProps {
@@ -14,7 +14,10 @@ interface DurationSelectorProps {
   onValueChange: (value: WorkoutDuration | null) => void;
 }
 
-export function DurationSelector({ value, onValueChange }: DurationSelectorProps) {
+export function DurationSelector({
+  value,
+  onValueChange,
+}: DurationSelectorProps) {
   return (
     <FormSection label="Duration">
       <div className="flex flex-wrap gap-2">

--- a/components/equipment-selector.tsx
+++ b/components/equipment-selector.tsx
@@ -7,10 +7,10 @@ import {
 } from "@/lib/workout-options";
 
 const GYM_LABELS: Record<GymProfile, string> = {
-  "Bodyweight Only":             "Bodyweight",
+  "Bodyweight Only": "Bodyweight",
   "Minimal Apartment/Hotel Gym": "Minimal Gym",
-  "Home Dumbbells and Bench":    "Home Gym",
-  "Full Commercial Gym":         "Commercial Gym",
+  "Home Dumbbells and Bench": "Home Gym",
+  "Full Commercial Gym": "Commercial Gym",
 };
 
 interface EquipmentSelectorProps {
@@ -31,7 +31,7 @@ export function EquipmentSelector({
   return (
     <FormSection label="Equipment" sub="Gym setup">
       {/* Gym profile chips: 2-column grid */}
-      <div className="grid grid-cols-2 gap-2 mb-4">
+      <div className="mb-4 grid grid-cols-2 gap-2">
         {gymProfiles.map((profile) => (
           <Chip
             key={profile}
@@ -47,10 +47,7 @@ export function EquipmentSelector({
       {/* Extra equipment chips */}
       {!isFullGym && (
         <>
-          <div
-            className="text-[11px] font-semibold tracking-[0.06em] uppercase mb-[10px]"
-            style={{ color: "#555", opacity: 0.7 }}
-          >
+          <div className="text-muted-foreground mb-[10px] text-[11px] font-semibold tracking-[0.06em] uppercase opacity-70">
             Extra equipment
           </div>
           <div className="flex flex-wrap gap-[7px]">
@@ -68,10 +65,7 @@ export function EquipmentSelector({
       )}
 
       {isFullGym && (
-        <div
-          className="px-[14px] py-[10px] rounded-[var(--wg-radius-sm)] text-[12px]"
-          style={{ background: "#181818", color: "#555" }}
-        >
+        <div className="rounded-wg-sm bg-muted text-muted-foreground px-[14px] py-[10px] text-[12px]">
           All commercial gym equipment included
         </div>
       )}

--- a/components/exercise-card.tsx
+++ b/components/exercise-card.tsx
@@ -27,72 +27,48 @@ export function ExerciseCard({ exercise, index }: ExerciseCardProps) {
   const [open, setOpen] = useState(true);
 
   return (
-    <div
-      className="border rounded-[var(--wg-radius)] overflow-hidden transition-colors duration-150 animate-fade-up"
-      style={{
-        background: "#111111",
-        borderColor: "#232323",
-        animationDelay: `${index * 60}ms`,
-      }}
-      onMouseEnter={(e) => (e.currentTarget.style.borderColor = "#2e2e2e")}
-      onMouseLeave={(e) => (e.currentTarget.style.borderColor = "#232323")}
-    >
+    <div className="animate-fade-up rounded-wg border-border bg-card hover:border-ring overflow-hidden border transition-colors duration-150">
       {/* Card header — always visible */}
       <div
-        className="flex items-center gap-[14px] px-5 py-4 cursor-pointer select-none"
+        className="flex cursor-pointer items-center gap-[14px] px-5 py-4 select-none"
         onClick={() => setOpen((o) => !o)}
       >
         {/* Number badge */}
-        <div
-          className="w-[34px] h-[34px] rounded-[7px] flex items-center justify-center text-[13px] font-bold flex-shrink-0"
-          style={{ background: "var(--wg-accent-sub)", color: "var(--wg-accent)" }}
-        >
+        <div className="bg-wg-accent-sub text-wg-accent flex h-[34px] w-[34px] flex-shrink-0 items-center justify-center rounded-[7px] text-[13px] font-bold">
           {index + 1}
         </div>
 
         {/* Name + muscle preview */}
-        <div className="flex-1 min-w-0">
-          <div
-            className="font-semibold text-[15px] leading-[1.2] truncate"
-            style={{ color: "#edeae6" }}
-          >
+        <div className="min-w-0 flex-1">
+          <div className="text-foreground truncate text-[15px] leading-[1.2] font-semibold">
             {exercise.name}
           </div>
-          <div className="text-[11px] mt-[3px]" style={{ color: "#555" }}>
+          <div className="text-muted-foreground mt-[3px] text-[11px]">
             {exercise.muscleGroups.slice(0, 3).join(" · ")}
           </div>
         </div>
 
         {/* Sets × Reps */}
-        <div className="flex-shrink-0 text-right mr-1">
-          <div
-            className="text-[15px] font-bold tracking-[-0.01em]"
-            style={{ color: "#edeae6" }}
-          >
+        <div className="mr-1 flex-shrink-0 text-right">
+          <div className="text-foreground text-[15px] font-bold">
             {exercise.sets}
-            <span style={{ color: "#555", fontWeight: 400 }}>×</span>
+            <span className="text-muted-foreground font-normal">×</span>
             {exercise.reps}
           </div>
-          <div
-            className="text-[10px] uppercase tracking-[0.05em] mt-[1px]"
-            style={{ color: "#555" }}
-          >
+          <div className="text-muted-foreground mt-[1px] text-[10px] tracking-[0.05em] uppercase">
             rest {exercise.restTime}
           </div>
         </div>
 
         {/* Chevron */}
-        <div style={{ color: "#2e2e2e", flexShrink: 0 }}>
+        <div className="text-ring flex-shrink-0">
           <ChevronIcon open={open} />
         </div>
       </div>
 
       {/* Expanded body */}
       {open && (
-        <div
-          className="border-t px-5 py-4 animate-fade-up-sm"
-          style={{ borderColor: "#232323" }}
-        >
+        <div className="animate-fade-up-sm border-border border-t px-5 py-4">
           <ExerciseDetails exercise={exercise} />
         </div>
       )}

--- a/components/exercise-details.tsx
+++ b/components/exercise-details.tsx
@@ -15,8 +15,8 @@ export function ExerciseDetails({
   compact = false,
 }: ExerciseDetailsProps) {
   const statPillClassName = compact
-    ? "inline-flex flex-col items-center px-[14px] py-[8px] min-w-[64px] rounded-[var(--wg-radius-sm)]"
-    : "inline-flex flex-col items-center px-[18px] py-[9px] min-w-[72px] rounded-[var(--wg-radius-sm)]";
+    ? "rounded-wg-sm inline-flex min-w-[64px] flex-col items-center px-[14px] py-[8px]"
+    : "rounded-wg-sm inline-flex min-w-[72px] flex-col items-center px-[18px] py-[9px]";
 
   const statValueClassName = compact
     ? "text-[16px] font-bold"
@@ -35,15 +35,11 @@ export function ExerciseDetails({
           { value: exercise.reps, label: "Reps" },
           { value: exercise.restTime, label: "Rest" },
         ].map(({ value, label }) => (
-          <div
-            key={label}
-            className={statPillClassName}
-            style={{ background: "#181818" }}
-          >
-            <span className={`${statValueClassName} text-[#edeae6]`}>
+          <div key={label} className={`${statPillClassName} bg-muted`}>
+            <span className={`${statValueClassName} text-foreground`}>
               {value}
             </span>
-            <span className="mt-[2px] text-[10px] uppercase tracking-[0.06em] text-[#8a857d]">
+            <span className="mt-[2px] text-[10px] tracking-[0.06em] text-zinc-400 uppercase">
               {label}
             </span>
           </div>
@@ -52,15 +48,11 @@ export function ExerciseDetails({
 
       {/* Muscle tags */}
       {exercise.muscleGroups.length > 0 && (
-        <div className="flex flex-wrap gap-[6px] mb-[14px]">
+        <div className="mb-[14px] flex flex-wrap gap-[6px]">
           {exercise.muscleGroups.map((muscle, i) => (
             <span
               key={i}
-              className="px-[9px] py-[3px] rounded-[4px] text-[11px] font-semibold tracking-[0.03em]"
-              style={{
-                background: "var(--wg-accent-sub)",
-                color: "var(--wg-accent)",
-              }}
+              className="bg-wg-accent-sub text-wg-accent rounded-[4px] px-[9px] py-[3px] text-[11px] font-semibold tracking-[0.03em]"
             >
               {muscle}
             </span>
@@ -71,18 +63,13 @@ export function ExerciseDetails({
       {/* Form tips */}
       {exercise.formTips.length > 0 && (
         <div>
-          <div className="mb-[9px] text-[10px] font-bold uppercase tracking-[0.08em] text-[#8a857d]">
+          <div className="mb-[9px] text-[10px] font-bold tracking-[0.08em] text-zinc-400 uppercase">
             Form Tips
           </div>
           <ul className="flex flex-col gap-[7px]">
             {exercise.formTips.map((tip, i) => (
-              <li key={i} className={`${tipClassName} text-[#8a857d]`}>
-                <span
-                  className="flex-shrink-0"
-                  style={{ color: "var(--wg-accent)" }}
-                >
-                  -
-                </span>
+              <li key={i} className={`${tipClassName} text-zinc-400`}>
+                <span className="text-wg-accent flex-shrink-0">-</span>
                 <span>{tip}</span>
               </li>
             ))}

--- a/components/program-results.tsx
+++ b/components/program-results.tsx
@@ -2,6 +2,7 @@
 
 import { forwardRef, useState } from "react";
 import { ExerciseDetails } from "@/components/exercise-details";
+import { cn } from "@/lib/utils";
 import type { ProgramData, ProgramDay } from "@/lib/workout-types";
 
 const CopyIcon = () => (
@@ -51,41 +52,31 @@ const ChevronIcon = ({ open }: { open: boolean }) => (
 
 function ProgramDayCard({
   day,
-  index,
+  dayNumber,
   isOpen,
   onToggle,
 }: {
   day: ProgramDay;
-  index: number;
+  dayNumber: number;
   isOpen: boolean;
   onToggle: () => void;
 }) {
   return (
-    <div
-      className="border rounded-[var(--wg-radius)] overflow-hidden animate-fade-up"
-      style={{
-        background: "#111111",
-        borderColor: "#232323",
-        animationDelay: `${index * 60}ms`,
-      }}
-    >
+    <div className="animate-fade-up rounded-wg border-border bg-card overflow-hidden border">
       <button
         type="button"
         aria-expanded={isOpen}
-        className="flex w-full items-center gap-[14px] bg-transparent px-5 py-4 text-left cursor-pointer select-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[var(--wg-accent)]"
+        className="focus-visible:outline-wg-accent flex w-full cursor-pointer items-center gap-[14px] bg-transparent px-5 py-4 text-left select-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px]"
         onClick={onToggle}
       >
-        <div
-          className="w-[34px] h-[34px] rounded-[7px] flex items-center justify-center text-[11px] font-bold flex-shrink-0 tracking-[0.02em]"
-          style={{ background: "var(--wg-accent-sub)", color: "var(--wg-accent)" }}
-        >
-          D{index + 1}
+        <div className="bg-wg-accent-sub text-wg-accent flex h-[34px] w-[34px] flex-shrink-0 items-center justify-center rounded-[7px] text-[11px] font-bold tracking-[0.02em]">
+          D{dayNumber}
         </div>
-        <div className="flex-1 min-w-0">
-          <div className="font-semibold text-[14px] text-[#edeae6]">
+        <div className="min-w-0 flex-1">
+          <div className="text-foreground text-[14px] font-semibold">
             {day.day} — {day.title}
           </div>
-          <div className="mt-[2px] flex flex-col gap-x-2 gap-y-[2px] text-[12px] text-[#8a857d] sm:flex-row sm:flex-wrap sm:items-center">
+          <div className="mt-[2px] flex flex-col gap-x-2 gap-y-[2px] text-[12px] text-zinc-400 sm:flex-row sm:flex-wrap sm:items-center">
             {day.focus && <span>{day.focus}</span>}
             {day.focus && (
               <span className="hidden sm:inline" aria-hidden="true">
@@ -95,48 +86,44 @@ function ProgramDayCard({
             <span>Est. {day.estimatedDuration}</span>
           </div>
         </div>
-        <div style={{ color: "#2e2e2e", flexShrink: 0 }}>
+        <div className="text-ring flex-shrink-0">
           <ChevronIcon open={isOpen} />
         </div>
       </button>
 
       {isOpen && (
-        <div
-          className="border-t px-5 py-[14px] animate-fade-up-sm"
-          style={{ borderColor: "#232323" }}
-        >
+        <div className="animate-fade-up-sm border-border border-t px-5 py-[14px]">
           {day.exercises.map((ex, j) => {
             const musclePreview = ex.muscleGroups.slice(0, 3).join(", ");
 
             return (
               <div
                 key={j}
-                className="py-4"
-                style={{
-                  borderBottom:
-                    j < day.exercises.length - 1
-                      ? "1px solid #232323"
-                      : "none",
-                }}
+                className={cn(
+                  "py-4",
+                  j < day.exercises.length - 1 && "border-border border-b",
+                )}
               >
                 <div className="flex items-start gap-3">
-                  <span className="w-4 flex-shrink-0 pt-[3px] text-[11px] text-[#8a857d]">
+                  <span className="w-4 flex-shrink-0 pt-[3px] text-[11px] text-zinc-400">
                     {j + 1}
                   </span>
                   <div className="min-w-0 flex-1">
                     <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
                       <div className="min-w-0">
-                        <div className="text-[14px] font-medium leading-[1.35] text-[#edeae6]">
+                        <div className="text-foreground text-[14px] leading-[1.35] font-medium">
                           {ex.name}
                         </div>
                         {musclePreview && (
-                          <div className="mt-[3px] text-[12px] leading-[1.45] text-[#8a857d]">
+                          <div className="mt-[3px] text-[12px] leading-[1.45] text-zinc-400">
                             {musclePreview}
                           </div>
                         )}
                       </div>
-                      <div className="flex flex-wrap gap-x-3 gap-y-1 text-[12px] font-medium text-[#8a857d] sm:flex-shrink-0 sm:justify-end sm:text-right">
-                        <span>{ex.sets} x {ex.reps}</span>
+                      <div className="flex flex-wrap gap-x-3 gap-y-1 text-[12px] font-medium text-zinc-400 sm:flex-shrink-0 sm:justify-end sm:text-right">
+                        <span>
+                          {ex.sets} x {ex.reps}
+                        </span>
                         <span>rest {ex.restTime}</span>
                       </div>
                     </div>
@@ -149,7 +136,7 @@ function ProgramDayCard({
             );
           })}
           {day.notes && (
-            <div className="mt-3 rounded-[var(--wg-radius-sm)] bg-[#181818] px-3 py-2 text-[12px] leading-[1.5] text-[#8a857d]">
+            <div className="rounded-wg-sm bg-muted mt-3 px-3 py-2 text-[12px] leading-[1.5] text-zinc-400">
               {day.notes}
             </div>
           )}
@@ -173,34 +160,28 @@ export const ProgramResults = forwardRef<HTMLDivElement, ProgramResultsProps>(
     return (
       <div ref={ref}>
         {/* Header card */}
-        <div
-          className="border rounded-[var(--wg-radius-lg)] px-[22px] py-5 mb-3 animate-fade-up"
-          style={{ background: "#111111", borderColor: "#232323" }}
-        >
-          <div className="flex items-start justify-between gap-4 flex-wrap">
+        <div className="animate-fade-up rounded-wg-lg border-border bg-card mb-3 border px-[22px] py-5">
+          <div className="flex flex-wrap items-start justify-between gap-4">
             <div>
-              <div
-                className="text-[10px] font-bold uppercase tracking-[0.08em] mb-[6px]"
-                style={{ color: "var(--wg-accent)" }}
-              >
+              <div className="text-wg-accent mb-[6px] text-[10px] font-bold tracking-[0.08em] uppercase">
                 Generated Program
               </div>
-              <div className="text-[22px] font-bold tracking-[-0.02em] text-[#edeae6]">
+              <div className="text-foreground text-[22px] font-bold">
                 Your Program
               </div>
-              <div className="mt-1 max-w-[420px] text-[13px] leading-[1.6] text-[#8a857d]">
+              <div className="mt-1 max-w-[420px] text-[13px] leading-[1.6] text-zinc-400">
                 {program.weeklyOverview ||
                   `${program.days.length}-day training program`}
               </div>
             </div>
-            <div className="flex gap-2 flex-wrap">
+            <div className="flex flex-wrap gap-2">
               <button
                 type="button"
                 onClick={onCopyFull}
-                className={`inline-flex cursor-pointer items-center gap-[6px] rounded-[var(--wg-radius-sm)] border px-[14px] py-2 text-[13px] font-medium leading-none transition-all duration-150 ${
+                className={`rounded-wg-sm inline-flex cursor-pointer items-center gap-[6px] border px-[14px] py-2 text-[13px] leading-none font-medium transition-all duration-150 ${
                   copiedFull
-                    ? "border-[var(--wg-accent)] text-[var(--wg-accent)]"
-                    : "border-[#232323] text-[#8a857d]"
+                    ? "border-wg-accent text-wg-accent"
+                    : "border-border text-zinc-400"
                 }`}
               >
                 {copiedFull ? <CheckIcon /> : <CopyIcon />}
@@ -210,7 +191,7 @@ export const ProgramResults = forwardRef<HTMLDivElement, ProgramResultsProps>(
               <button
                 type="button"
                 onClick={onReset}
-                className="inline-flex cursor-pointer items-center rounded-[var(--wg-radius-sm)] border border-[#232323] bg-transparent px-[14px] py-2 text-[13px] font-medium leading-none text-[#8a857d] transition-all duration-150 hover:border-[#2e2e2e] hover:text-[#edeae6]"
+                className="rounded-wg-sm border-border hover:border-ring hover:text-foreground inline-flex cursor-pointer items-center border bg-transparent px-[14px] py-2 text-[13px] leading-none font-medium text-zinc-400 transition-all duration-150"
               >
                 New Program
               </button>
@@ -218,7 +199,7 @@ export const ProgramResults = forwardRef<HTMLDivElement, ProgramResultsProps>(
           </div>
         </div>
 
-        <div className="mb-[10px] text-[10px] font-bold uppercase tracking-[0.08em] text-[#8a857d]">
+        <div className="mb-[10px] text-[10px] font-bold tracking-[0.08em] text-zinc-400 uppercase">
           Week 1 — Sample Schedule
         </div>
 
@@ -228,7 +209,7 @@ export const ProgramResults = forwardRef<HTMLDivElement, ProgramResultsProps>(
             <ProgramDayCard
               key={day.day}
               day={day}
-              index={i}
+              dayNumber={i + 1}
               isOpen={openDay === i}
               onToggle={() => setOpenDay(openDay === i ? -1 : i)}
             />
@@ -236,8 +217,8 @@ export const ProgramResults = forwardRef<HTMLDivElement, ProgramResultsProps>(
         </div>
 
         {program.progressionNotes && (
-          <div className="mt-4 rounded-[var(--wg-radius)] border border-[#232323] bg-[#111111] px-[14px] py-3 text-[13px] leading-[1.6] text-[#8a857d]">
-            <div className="mb-[7px] text-[10px] font-bold uppercase tracking-[0.08em] text-[#8a857d]">
+          <div className="rounded-wg border-border bg-card mt-4 border px-[14px] py-3 text-[13px] leading-[1.6] text-zinc-400">
+            <div className="mb-[7px] text-[10px] font-bold tracking-[0.08em] text-zinc-400 uppercase">
               Progression Plan
             </div>
             <div>{program.progressionNotes}</div>

--- a/components/settings-menu.tsx
+++ b/components/settings-menu.tsx
@@ -85,7 +85,7 @@ export function TweaksPanel({ tweaks, onUpdate, onClose }: TweaksPanelProps) {
               type="button"
               onClick={() => onUpdate("accentOklch", p.oklch)}
               className={cn(
-                "h-6 w-6 cursor-pointer rounded-full border-2 transition-transform duration-150 hover:scale-110",
+                "h-6 w-6 cursor-pointer rounded-full border-2 transition-colors duration-150",
                 p.className,
                 tweaks.accentOklch === p.oklch
                   ? "border-foreground"
@@ -108,11 +108,11 @@ export function TweaksPanel({ tweaks, onUpdate, onClose }: TweaksPanelProps) {
               type="button"
               onClick={() => onUpdate("fontFamily", font)}
               className={cn(
-                "cursor-pointer rounded-[6px] border px-[10px] py-[6px] text-left text-[13px] transition-all duration-150",
+                "cursor-pointer rounded-[6px] border px-[10px] py-[6px] text-left text-[13px] font-semibold transition-all duration-150",
                 FONT_CLASS_NAMES[font],
                 tweaks.fontFamily === font
-                  ? "border-wg-accent bg-wg-accent-sub text-wg-accent font-semibold"
-                  : "border-border text-muted-foreground bg-transparent font-normal",
+                  ? "border-wg-accent bg-wg-accent-sub text-wg-accent"
+                  : "border-border text-muted-foreground bg-transparent",
               )}
             >
               {font}
@@ -133,10 +133,10 @@ export function TweaksPanel({ tweaks, onUpdate, onClose }: TweaksPanelProps) {
               type="button"
               onClick={() => onUpdate("cardRadius", r.value)}
               className={cn(
-                "font-wg flex-1 cursor-pointer rounded-[6px] border py-[6px] text-[12px] transition-all duration-150",
+                "font-wg flex-1 cursor-pointer rounded-[6px] border py-[6px] text-[12px] font-semibold transition-all duration-150",
                 tweaks.cardRadius === r.value
-                  ? "border-wg-accent bg-wg-accent-sub text-wg-accent font-semibold"
-                  : "border-border text-muted-foreground bg-transparent font-normal",
+                  ? "border-wg-accent bg-wg-accent-sub text-wg-accent"
+                  : "border-border text-muted-foreground bg-transparent",
               )}
             >
               {r.label}

--- a/components/settings-menu.tsx
+++ b/components/settings-menu.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { cn } from "@/lib/utils";
+
 export interface TweaksState {
   accentOklch: string;
   fontFamily: string;
@@ -13,17 +15,38 @@ export const TWEAKS_DEFAULTS: TweaksState = {
 };
 
 const ACCENT_PRESETS = [
-  { label: "Crimson",  oklch: "0.44 0.17 13"  },
-  { label: "Scarlet",  oklch: "0.46 0.20 22"  },
-  { label: "Burgundy", oklch: "0.38 0.14 5"   },
-  { label: "Garnet",   oklch: "0.42 0.15 350" },
+  {
+    label: "Crimson",
+    oklch: "0.44 0.17 13",
+    className: "bg-[oklch(0.44_0.17_13)]",
+  },
+  {
+    label: "Scarlet",
+    oklch: "0.46 0.20 22",
+    className: "bg-[oklch(0.46_0.20_22)]",
+  },
+  {
+    label: "Burgundy",
+    oklch: "0.38 0.14 5",
+    className: "bg-[oklch(0.38_0.14_5)]",
+  },
+  {
+    label: "Garnet",
+    oklch: "0.42 0.15 350",
+    className: "bg-[oklch(0.42_0.15_350)]",
+  },
 ];
 
 const FONT_OPTIONS = ["Space Grotesk", "DM Sans", "Helvetica Neue"];
+const FONT_CLASS_NAMES: Record<string, string> = {
+  "Space Grotesk": "font-space-grotesk",
+  "DM Sans": "font-dm-sans",
+  "Helvetica Neue": "font-helvetica-neue",
+};
 const RADIUS_OPTIONS = [
-  { value: "4",  label: "Sharp"   },
-  { value: "8",  label: "Rounded" },
-  { value: "14", label: "Soft"    },
+  { value: "4", label: "Sharp" },
+  { value: "8", label: "Rounded" },
+  { value: "14", label: "Soft" },
 ];
 
 interface TweaksPanelProps {
@@ -34,27 +57,16 @@ interface TweaksPanelProps {
 
 export function TweaksPanel({ tweaks, onUpdate, onClose }: TweaksPanelProps) {
   return (
-    <div
-      className="fixed bottom-6 right-6 z-50 w-[240px] rounded-[var(--wg-radius-lg)] p-5 animate-fade-up"
-      style={{
-        background: "#111111",
-        border: "1px solid #2e2e2e",
-        boxShadow: "0 24px 48px rgba(0,0,0,0.5)",
-      }}
-    >
+    <div className="animate-fade-up shadow-tweaks rounded-wg-lg border-ring bg-card fixed right-6 bottom-6 z-50 w-[240px] border p-5">
       {/* Header */}
-      <div className="flex items-center justify-between mb-[18px]">
-        <div
-          className="text-[13px] font-bold tracking-[0.02em]"
-          style={{ color: "#edeae6" }}
-        >
+      <div className="mb-[18px] flex items-center justify-between">
+        <div className="text-foreground text-[13px] font-bold tracking-[0.02em]">
           Tweaks
         </div>
         <button
           type="button"
           onClick={onClose}
-          className="text-[18px] leading-none cursor-pointer transition-colors duration-150 hover:text-[#edeae6]"
-          style={{ background: "none", border: "none", color: "#555", padding: 0 }}
+          className="text-muted-foreground hover:text-foreground cursor-pointer border-none bg-transparent p-0 text-[18px] leading-none transition-colors duration-150"
         >
           ×
         </button>
@@ -62,10 +74,7 @@ export function TweaksPanel({ tweaks, onUpdate, onClose }: TweaksPanelProps) {
 
       {/* Accent color */}
       <div className="mb-4">
-        <div
-          className="text-[10px] font-bold uppercase tracking-[0.08em] mb-[10px]"
-          style={{ color: "#555" }}
-        >
+        <div className="text-muted-foreground mb-[10px] text-[10px] font-bold tracking-[0.08em] uppercase">
           Accent Color
         </div>
         <div className="flex gap-[10px]">
@@ -75,12 +84,13 @@ export function TweaksPanel({ tweaks, onUpdate, onClose }: TweaksPanelProps) {
               title={p.label}
               type="button"
               onClick={() => onUpdate("accentOklch", p.oklch)}
-              className="w-6 h-6 rounded-full cursor-pointer transition-transform duration-150 hover:scale-110 border-2"
-              style={{
-                background: `oklch(${p.oklch})`,
-                borderColor:
-                  tweaks.accentOklch === p.oklch ? "#edeae6" : "transparent",
-              }}
+              className={cn(
+                "h-6 w-6 cursor-pointer rounded-full border-2 transition-transform duration-150 hover:scale-110",
+                p.className,
+                tweaks.accentOklch === p.oklch
+                  ? "border-foreground"
+                  : "border-transparent",
+              )}
             />
           ))}
         </div>
@@ -88,10 +98,7 @@ export function TweaksPanel({ tweaks, onUpdate, onClose }: TweaksPanelProps) {
 
       {/* Font */}
       <div className="mb-4">
-        <div
-          className="text-[10px] font-bold uppercase tracking-[0.08em] mb-[10px]"
-          style={{ color: "#555" }}
-        >
+        <div className="text-muted-foreground mb-[10px] text-[10px] font-bold tracking-[0.08em] uppercase">
           Font
         </div>
         <div className="flex flex-col gap-[6px]">
@@ -100,18 +107,13 @@ export function TweaksPanel({ tweaks, onUpdate, onClose }: TweaksPanelProps) {
               key={font}
               type="button"
               onClick={() => onUpdate("fontFamily", font)}
-              className="text-left px-[10px] py-[6px] rounded-[6px] text-[13px] cursor-pointer transition-all duration-150"
-              style={{
-                fontFamily: font,
-                border: `1px solid ${tweaks.fontFamily === font ? "var(--wg-accent)" : "#232323"}`,
-                background:
-                  tweaks.fontFamily === font
-                    ? "var(--wg-accent-sub)"
-                    : "transparent",
-                color:
-                  tweaks.fontFamily === font ? "var(--wg-accent)" : "#555",
-                fontWeight: tweaks.fontFamily === font ? 600 : 400,
-              }}
+              className={cn(
+                "cursor-pointer rounded-[6px] border px-[10px] py-[6px] text-left text-[13px] transition-all duration-150",
+                FONT_CLASS_NAMES[font],
+                tweaks.fontFamily === font
+                  ? "border-wg-accent bg-wg-accent-sub text-wg-accent font-semibold"
+                  : "border-border text-muted-foreground bg-transparent font-normal",
+              )}
             >
               {font}
             </button>
@@ -121,10 +123,7 @@ export function TweaksPanel({ tweaks, onUpdate, onClose }: TweaksPanelProps) {
 
       {/* Card radius */}
       <div>
-        <div
-          className="text-[10px] font-bold uppercase tracking-[0.08em] mb-[10px]"
-          style={{ color: "#555" }}
-        >
+        <div className="text-muted-foreground mb-[10px] text-[10px] font-bold tracking-[0.08em] uppercase">
           Card Radius
         </div>
         <div className="flex gap-2">
@@ -133,18 +132,12 @@ export function TweaksPanel({ tweaks, onUpdate, onClose }: TweaksPanelProps) {
               key={r.value}
               type="button"
               onClick={() => onUpdate("cardRadius", r.value)}
-              className="flex-1 py-[6px] text-[12px] rounded-[6px] cursor-pointer transition-all duration-150"
-              style={{
-                fontFamily: "var(--wg-font)",
-                border: `1px solid ${tweaks.cardRadius === r.value ? "var(--wg-accent)" : "#232323"}`,
-                background:
-                  tweaks.cardRadius === r.value
-                    ? "var(--wg-accent-sub)"
-                    : "transparent",
-                color:
-                  tweaks.cardRadius === r.value ? "var(--wg-accent)" : "#555",
-                fontWeight: tweaks.cardRadius === r.value ? 600 : 400,
-              }}
+              className={cn(
+                "font-wg flex-1 cursor-pointer rounded-[6px] border py-[6px] text-[12px] transition-all duration-150",
+                tweaks.cardRadius === r.value
+                  ? "border-wg-accent bg-wg-accent-sub text-wg-accent font-semibold"
+                  : "border-border text-muted-foreground bg-transparent font-normal",
+              )}
             >
               {r.label}
             </button>

--- a/components/split-workout-selector.tsx
+++ b/components/split-workout-selector.tsx
@@ -2,12 +2,12 @@ import { Chip, FormSection } from "@/components/chip";
 import { workoutTypes, type WorkoutType } from "@/lib/workout-options";
 
 const SPLIT_LABELS: Record<WorkoutType, string> = {
-  "Leg Workout":        "Legs",
-  "Push Workout":       "Push",
-  "Pull Workout":       "Pull",
+  "Leg Workout": "Legs",
+  "Push Workout": "Push",
+  "Pull Workout": "Pull",
   "Upper Body Workout": "Upper Body",
   "Lower Body Workout": "Lower Body",
-  "Full Body Workout":  "Full Body",
+  "Full Body Workout": "Full Body",
 };
 
 interface SplitWorkoutSelectorProps {

--- a/components/submit-button.tsx
+++ b/components/submit-button.tsx
@@ -15,26 +15,11 @@ export function SubmitButton({ mode, loading, canSubmit }: SubmitButtonProps) {
       <button
         type="submit"
         disabled={isDisabled}
-        className="w-full py-[15px] text-[13px] font-bold uppercase tracking-[0.08em] rounded-[var(--wg-radius)] border-none transition-colors duration-200"
-        style={{
-          background: isDisabled ? "#181818" : "var(--wg-accent)",
-          color: isDisabled ? "#2e2e2e" : "#ffffff",
-          cursor: isDisabled ? "not-allowed" : "pointer",
-          fontFamily: "var(--wg-font)",
-        }}
-        onMouseEnter={(e) => {
-          if (!isDisabled) e.currentTarget.style.background = "var(--wg-accent-h)";
-        }}
-        onMouseLeave={(e) => {
-          if (!isDisabled) e.currentTarget.style.background = "var(--wg-accent)";
-        }}
+        className="font-wg rounded-wg bg-wg-accent hover:bg-wg-accent-hover disabled:bg-muted disabled:text-ring disabled:hover:bg-muted w-full cursor-pointer border-none py-[15px] text-[13px] font-bold tracking-[0.08em] text-white uppercase transition-colors duration-200 disabled:cursor-not-allowed"
       >
         {loading ? (
           <span className="flex items-center justify-center gap-2">
-            <span
-              className="inline-block w-4 h-4 rounded-full border-2 border-current border-t-transparent"
-              style={{ animation: "spinLoader 0.7s linear infinite" }}
-            />
+            <span className="animate-spin-loader inline-block h-4 w-4 rounded-full border-2 border-current border-t-transparent" />
             Generating {label}…
           </span>
         ) : (
@@ -43,19 +28,13 @@ export function SubmitButton({ mode, loading, canSubmit }: SubmitButtonProps) {
       </button>
 
       {mode === "workout" && !canSubmit && !loading && (
-        <p
-          className="text-[12px] text-center mt-[10px]"
-          style={{ color: "#555" }}
-        >
+        <p className="text-muted-foreground mt-[10px] text-center text-[12px]">
           Select a workout split or body part to continue
         </p>
       )}
 
       {mode === "program" && !canSubmit && !loading && (
-        <p
-          className="text-[12px] text-center mt-[10px]"
-          style={{ color: "#555" }}
-        >
+        <p className="text-muted-foreground mt-[10px] text-center text-[12px]">
           Select a program split to continue
         </p>
       )}

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -41,7 +41,7 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "ring-offset-background focus-visible:ring-ring inline-flex items-center justify-center rounded-md px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+        "ring-offset-background focus-visible:ring-ring data-[state=active]:bg-background data-[state=active]:text-foreground inline-flex items-center justify-center rounded-md px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm",
         className,
       )}
       {...props}
@@ -56,7 +56,10 @@ function TabsContent({
   return (
     <TabsPrimitive.Content
       data-slot="tabs-content"
-      className={cn("focus-visible:ring-ring focus-visible:outline-none", className)}
+      className={cn(
+        "focus-visible:ring-ring focus-visible:outline-none",
+        className,
+      )}
       {...props}
     />
   );

--- a/components/workout-header.tsx
+++ b/components/workout-header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { GenerationMode } from "@/lib/generation-types";
+import { cn } from "@/lib/utils";
 
 const BarbellIcon = ({ size = 26 }: { size?: number }) => (
   <svg
@@ -9,11 +10,11 @@ const BarbellIcon = ({ size = 26 }: { size?: number }) => (
     viewBox="0 0 48 24"
     fill="currentColor"
   >
-    <rect x="0"  y="6"  width="5"  height="12" rx="2" />
-    <rect x="5"  y="3"  width="3"  height="18" rx="1.5" />
-    <rect x="8"  y="10" width="32" height="4"  rx="2" />
-    <rect x="40" y="3"  width="3"  height="18" rx="1.5" />
-    <rect x="43" y="6"  width="5"  height="12" rx="2" />
+    <rect x="0" y="6" width="5" height="12" rx="2" />
+    <rect x="5" y="3" width="3" height="18" rx="1.5" />
+    <rect x="8" y="10" width="32" height="4" rx="2" />
+    <rect x="40" y="3" width="3" height="18" rx="1.5" />
+    <rect x="43" y="6" width="5" height="12" rx="2" />
   </svg>
 );
 
@@ -47,22 +48,16 @@ export function WorkoutHeader({
   return (
     <div className="mb-8">
       {/* Top bar: logo + settings */}
-      <div className="flex items-start justify-between mb-8">
+      <div className="mb-8 flex items-start justify-between">
         <div className="flex items-center gap-[14px]">
-          <div
-            className="w-[46px] h-[46px] rounded-[11px] flex items-center justify-center flex-shrink-0"
-            style={{ background: "var(--wg-accent-sub)", color: "var(--wg-accent)" }}
-          >
+          <div className="bg-wg-accent-sub text-wg-accent flex h-[46px] w-[46px] flex-shrink-0 items-center justify-center rounded-[11px]">
             <BarbellIcon size={26} />
           </div>
           <div>
-            <h1
-              className="text-2xl font-bold tracking-[-0.025em] leading-[1.1]"
-              style={{ color: "#edeae6" }}
-            >
+            <h1 className="text-foreground text-2xl leading-[1.1] font-bold">
               Workout Generator
             </h1>
-            <p className="text-xs mt-1" style={{ color: "#555" }}>
+            <p className="text-muted-foreground mt-1 text-xs">
               AI-powered personalized workouts &amp; weekly programs
             </p>
           </div>
@@ -72,29 +67,25 @@ export function WorkoutHeader({
           type="button"
           onClick={onToggleTweaks}
           title="Tweaks"
-          className="border rounded-[8px] p-2 flex items-center justify-center transition-all duration-150 hover:border-[#2e2e2e] hover:text-[#edeae6] cursor-pointer"
-          style={{ background: "transparent", borderColor: "#232323", color: "#555" }}
+          className="border-border text-muted-foreground hover:border-ring hover:text-foreground flex cursor-pointer items-center justify-center rounded-[8px] border bg-transparent p-2 transition-all duration-150"
         >
           <SettingsIcon />
         </button>
       </div>
 
       {/* Mode toggle pill */}
-      <div
-        className="inline-flex border rounded-[11px] p-1 gap-[2px]"
-        style={{ background: "#111111", borderColor: "#232323" }}
-      >
+      <div className="border-border bg-card inline-flex gap-[2px] rounded-[11px] border p-1">
         {(["workout", "program"] as GenerationMode[]).map((m) => (
           <button
             key={m}
             type="button"
             onClick={() => onModeChange(m)}
-            className="px-[22px] py-[7px] text-[13px] rounded-[7px] border-none transition-all duration-150 cursor-pointer tracking-[0.01em]"
-            style={{
-              background: mode === m ? "#202020" : "transparent",
-              color: mode === m ? "#edeae6" : "#555",
-              fontWeight: mode === m ? 600 : 500,
-            }}
+            className={cn(
+              "cursor-pointer rounded-[7px] border-none px-[22px] py-[7px] text-[13px] transition-all duration-150",
+              mode === m
+                ? "bg-secondary text-foreground font-semibold"
+                : "text-muted-foreground bg-transparent font-medium",
+            )}
           >
             {m === "workout" ? "Workout" : "Program"}
           </button>

--- a/components/workout-header.tsx
+++ b/components/workout-header.tsx
@@ -81,10 +81,10 @@ export function WorkoutHeader({
             type="button"
             onClick={() => onModeChange(m)}
             className={cn(
-              "cursor-pointer rounded-[7px] border-none px-[22px] py-[7px] text-[13px] transition-all duration-150",
+              "cursor-pointer rounded-[7px] border-none px-[22px] py-[7px] text-[13px] font-semibold transition-all duration-150",
               mode === m
-                ? "bg-secondary text-foreground font-semibold"
-                : "text-muted-foreground bg-transparent font-medium",
+                ? "bg-secondary text-foreground"
+                : "text-muted-foreground bg-transparent",
             )}
           >
             {m === "workout" ? "Workout" : "Program"}

--- a/components/workout-results.tsx
+++ b/components/workout-results.tsx
@@ -47,40 +47,30 @@ export const WorkoutResults = forwardRef<HTMLDivElement, WorkoutResultsProps>(
     return (
       <div ref={ref}>
         {/* Header card */}
-        <div
-          className="border rounded-[var(--wg-radius-lg)] px-[22px] py-5 mb-3 animate-fade-up"
-          style={{ background: "#111111", borderColor: "#232323" }}
-        >
-          <div className="flex items-start justify-between gap-4 flex-wrap">
+        <div className="animate-fade-up rounded-wg-lg border-border bg-card mb-3 border px-[22px] py-5">
+          <div className="flex flex-wrap items-start justify-between gap-4">
             <div>
-              <div
-                className="text-[10px] font-bold uppercase tracking-[0.08em] mb-[6px]"
-                style={{ color: "var(--wg-accent)" }}
-              >
+              <div className="text-wg-accent mb-[6px] text-[10px] font-bold tracking-[0.08em] uppercase">
                 Generated Workout
               </div>
-              <div
-                className="text-[22px] font-bold tracking-[-0.02em]"
-                style={{ color: "#edeae6" }}
-              >
+              <div className="text-foreground text-[22px] font-bold">
                 Your Workout
               </div>
-              <div className="text-[13px] mt-1" style={{ color: "#555" }}>
+              <div className="text-muted-foreground mt-1 text-[13px]">
                 Est. {workout.estimatedDuration}
               </div>
             </div>
 
-            <div className="flex gap-2 flex-wrap">
+            <div className="flex flex-wrap gap-2">
               {/* Copy button */}
               <button
                 type="button"
                 onClick={onCopyFull}
-                className="inline-flex items-center gap-[6px] px-[14px] py-2 text-[13px] font-medium rounded-[var(--wg-radius-sm)] border transition-all duration-150 cursor-pointer leading-none"
-                style={{
-                  background: "transparent",
-                  borderColor: copiedFull ? "var(--wg-accent)" : "#232323",
-                  color: copiedFull ? "var(--wg-accent)" : "#555",
-                }}
+                className={`rounded-wg-sm inline-flex cursor-pointer items-center gap-[6px] border bg-transparent px-[14px] py-2 text-[13px] leading-none font-medium transition-all duration-150 ${
+                  copiedFull
+                    ? "border-wg-accent text-wg-accent"
+                    : "border-border text-muted-foreground"
+                }`}
               >
                 {copiedFull ? <CheckIcon /> : <CopyIcon />}
                 {copiedFull ? "Copied" : "Copy"}
@@ -90,8 +80,7 @@ export const WorkoutResults = forwardRef<HTMLDivElement, WorkoutResultsProps>(
               <button
                 type="button"
                 onClick={onReset}
-                className="inline-flex items-center gap-[6px] px-[14px] py-2 text-[13px] font-medium rounded-[var(--wg-radius-sm)] border border-[#232323] transition-all duration-150 cursor-pointer leading-none hover:border-[#2e2e2e] hover:text-[#edeae6]"
-                style={{ background: "transparent", color: "#555" }}
+                className="rounded-wg-sm border-border text-muted-foreground hover:border-ring hover:text-foreground inline-flex cursor-pointer items-center gap-[6px] border bg-transparent px-[14px] py-2 text-[13px] leading-none font-medium transition-all duration-150"
               >
                 New Workout
               </button>
@@ -99,10 +88,7 @@ export const WorkoutResults = forwardRef<HTMLDivElement, WorkoutResultsProps>(
           </div>
 
           {workout.notes && (
-            <div
-              className="mt-4 px-[14px] py-[11px] rounded-[var(--wg-radius-sm)] text-[13px] leading-[1.6]"
-              style={{ background: "#181818", color: "#555" }}
-            >
+            <div className="rounded-wg-sm bg-muted text-muted-foreground mt-4 px-[14px] py-[11px] text-[13px] leading-[1.6]">
               {workout.notes}
             </div>
           )}

--- a/lib/ai-generation.ts
+++ b/lib/ai-generation.ts
@@ -42,18 +42,21 @@ export async function fetchOpenRouterCompletion(
     stream: false,
   };
 
-  const response = await fetch("https://openrouter.ai/api/v1/chat/completions", {
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${process.env.OPENROUTER_API_KEY ?? ""}`,
-      "HTTP-Referer": process.env.VERCEL_URL
-        ? `https://${process.env.VERCEL_URL}`
-        : "http://localhost:3000",
-      "X-Title": title,
+  const response = await fetch(
+    "https://openrouter.ai/api/v1/chat/completions",
+    {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${process.env.OPENROUTER_API_KEY ?? ""}`,
+        "HTTP-Referer": process.env.VERCEL_URL
+          ? `https://${process.env.VERCEL_URL}`
+          : "http://localhost:3000",
+        "X-Title": title,
+      },
+      method: "POST",
+      body: JSON.stringify(payload),
     },
-    method: "POST",
-    body: JSON.stringify(payload),
-  });
+  );
 
   if (!response.ok) {
     console.error("OpenRouter API Error:", response.status);

--- a/lib/hooks/use-generation-submit.ts
+++ b/lib/hooks/use-generation-submit.ts
@@ -62,10 +62,7 @@ export function useGenerationSubmit() {
         setResult({ mode: "workout", workout });
       }
     } catch (error) {
-      if (
-        error instanceof DOMException &&
-        error.name === "AbortError"
-      ) {
+      if (error instanceof DOMException && error.name === "AbortError") {
         return;
       }
 

--- a/lib/program-prompt.ts
+++ b/lib/program-prompt.ts
@@ -24,7 +24,9 @@ export function buildProgramPrompt(userInformation: WorkoutRequest) {
 
   // Days per week
   if (selectedDaysPerWeek) {
-    parts.push(`Return exactly ${selectedDaysPerWeek} workout days for the week.`);
+    parts.push(
+      `Return exactly ${selectedDaysPerWeek} workout days for the week.`,
+    );
   } else {
     parts.push(
       "Choose a sensible training frequency and return exactly 3, 4, or 5 workout days for the week.",
@@ -60,7 +62,9 @@ export function buildProgramPrompt(userInformation: WorkoutRequest) {
 
   // Gym setup
   if (userInformation.gymProfile) {
-    parts.push(`Available gym setup: ${userInformation.gymProfile.toLowerCase()}.`);
+    parts.push(
+      `Available gym setup: ${userInformation.gymProfile.toLowerCase()}.`,
+    );
   }
 
   if (userInformation.availableEquipment.length > 0) {
@@ -69,7 +73,10 @@ export function buildProgramPrompt(userInformation: WorkoutRequest) {
     );
   }
 
-  if (userInformation.gymProfile || userInformation.availableEquipment.length > 0) {
+  if (
+    userInformation.gymProfile ||
+    userInformation.availableEquipment.length > 0
+  ) {
     parts.push(
       "Only include exercises that can be performed with the available setup, listed equipment, or bodyweight.",
     );

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -86,14 +86,24 @@ export async function fetchWorkout(
   params: GenerationParams,
   signal?: AbortSignal,
 ): Promise<WorkoutData> {
-  return fetchGeneration<WorkoutData>("/api/workout", params, "workout", signal);
+  return fetchGeneration<WorkoutData>(
+    "/api/workout",
+    params,
+    "workout",
+    signal,
+  );
 }
 
 export async function fetchProgram(
   params: GenerationParams,
   signal?: AbortSignal,
 ): Promise<ProgramData> {
-  return fetchGeneration<ProgramData>("/api/program", params, "program", signal);
+  return fetchGeneration<ProgramData>(
+    "/api/program",
+    params,
+    "program",
+    signal,
+  );
 }
 
 export function formatWorkoutAsText(workout: WorkoutData): string {
@@ -132,12 +142,14 @@ export function formatWorkoutAsTemplate(workout: WorkoutData): string {
 export function formatProgramAsText(program: ProgramData): string {
   let text = `Weekly Program\n${"=".repeat(50)}\n\n`;
 
-  if (program.weeklyOverview) text += `Overview:\n${program.weeklyOverview}\n\n`;
+  if (program.weeklyOverview)
+    text += `Overview:\n${program.weeklyOverview}\n\n`;
 
   program.days.forEach((day) => {
     text += `${day.day} - ${day.title}\n`;
     if (day.focus) text += `Focus: ${day.focus}\n`;
-    if (day.estimatedDuration) text += `Estimated Duration: ${day.estimatedDuration}\n`;
+    if (day.estimatedDuration)
+      text += `Estimated Duration: ${day.estimatedDuration}\n`;
 
     if (day.exercises.length > 0) {
       text += "\n";
@@ -166,12 +178,14 @@ export function formatProgramAsText(program: ProgramData): string {
 export function formatProgramAsTemplate(program: ProgramData): string {
   let text = `Weekly Program Template\n${"=".repeat(50)}\n\n`;
 
-  if (program.weeklyOverview) text += `Overview:\n${program.weeklyOverview}\n\n`;
+  if (program.weeklyOverview)
+    text += `Overview:\n${program.weeklyOverview}\n\n`;
 
   program.days.forEach((day) => {
     text += `${day.day} - ${day.title}\n`;
     if (day.focus) text += `Focus: ${day.focus}\n`;
-    if (day.estimatedDuration) text += `Estimated Duration: ${day.estimatedDuration}\n`;
+    if (day.estimatedDuration)
+      text += `Estimated Duration: ${day.estimatedDuration}\n`;
 
     text += "\n";
     day.exercises.forEach((exercise, index) => {

--- a/lib/workout-options.ts
+++ b/lib/workout-options.ts
@@ -70,27 +70,39 @@ export interface MuscleGroupConfig {
 }
 
 export const muscleGroupConfig: Record<MuscleGroup, MuscleGroupConfig> = {
-  Quads:        { icon: Dumbbell,  color: "muscle-legs",      category: "legs" },
-  Hamstrings:   { icon: Dumbbell,  color: "muscle-legs",      category: "legs" },
-  Glutes:       { icon: Dumbbell,  color: "muscle-legs",      category: "legs" },
-  Chest:        { icon: Heart,     color: "muscle-upper",     category: "upper" },
-  Lats:         { icon: Activity,  color: "muscle-upper",     category: "upper" },
-  "Upper Back": { icon: Activity,  color: "muscle-upper",     category: "upper" },
-  Biceps:       { icon: Zap,       color: "muscle-arms",      category: "arms" },
-  Triceps:      { icon: Zap,       color: "muscle-arms",      category: "arms" },
-  "Front Delts":{ icon: Target,    color: "muscle-shoulders", category: "shoulders" },
-  "Side Delts": { icon: Target,    color: "muscle-shoulders", category: "shoulders" },
-  "Rear Delts": { icon: Target,    color: "muscle-shoulders", category: "shoulders" },
-  Abs:          { icon: Flame,     color: "muscle-core",      category: "core" },
+  Quads: { icon: Dumbbell, color: "muscle-legs", category: "legs" },
+  Hamstrings: { icon: Dumbbell, color: "muscle-legs", category: "legs" },
+  Glutes: { icon: Dumbbell, color: "muscle-legs", category: "legs" },
+  Chest: { icon: Heart, color: "muscle-upper", category: "upper" },
+  Lats: { icon: Activity, color: "muscle-upper", category: "upper" },
+  "Upper Back": { icon: Activity, color: "muscle-upper", category: "upper" },
+  Biceps: { icon: Zap, color: "muscle-arms", category: "arms" },
+  Triceps: { icon: Zap, color: "muscle-arms", category: "arms" },
+  "Front Delts": {
+    icon: Target,
+    color: "muscle-shoulders",
+    category: "shoulders",
+  },
+  "Side Delts": {
+    icon: Target,
+    color: "muscle-shoulders",
+    category: "shoulders",
+  },
+  "Rear Delts": {
+    icon: Target,
+    color: "muscle-shoulders",
+    category: "shoulders",
+  },
+  Abs: { icon: Flame, color: "muscle-core", category: "core" },
 };
 
 export const workoutTypeIcons: Record<WorkoutType, LucideIcon> = {
-  "Leg Workout":        Dumbbell,
-  "Push Workout":       Zap,
-  "Pull Workout":       Activity,
+  "Leg Workout": Dumbbell,
+  "Push Workout": Zap,
+  "Pull Workout": Activity,
   "Upper Body Workout": Heart,
   "Lower Body Workout": Dumbbell,
-  "Full Body Workout":  Flame,
+  "Full Body Workout": Flame,
 };
 
 export const workoutDurations = [


### PR DESCRIPTION
## Summary
- Replaced inline `style` props with Tailwind classes and a small set of shared utility classes.
- Simplified repeated color, radius, border, and background patterns across the form, header, results, and settings UI.
- Removed size-shifting selection states so chips, segmented controls, and swatches keep stable dimensions when active.

## Testing
- `pnpm lint` passed.
- `pnpm build` passed.
- Local browser validation confirmed selection toggles no longer change element size.